### PR TITLE
disable linebreak-style in eslint

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -101,10 +101,7 @@ module.exports = {
         "key-spacing": "off",
         "keyword-spacing": "off",
         "line-comment-position": "off",
-        "linebreak-style": [
-            "error",
-            "unix"
-        ],
+        "linebreak-style": "off",
         "lines-around-comment": "off",
         "lines-around-directive": "off",
         "max-depth": "error",


### PR DESCRIPTION
- we don't really care about the line endings, they will be whatever
works on the host.

Fixes: https://github.com/IBM-Cloud/gp-js-client/issues/109

see https://eslint.org/docs/rules/linebreak-style