### PR TITLE
Update tr-test.js

### DIFF
--- a/test/tr-test.js
+++ b/test/tr-test.js
@@ -180,7 +180,7 @@ describe('GP-HPE.bundle()', function () {
     var proj = gaasClient.bundle({ id: projectId, serviceInstance: instanceName });
     proj.create({
       sourceLanguage: srcLang,
-      targetLanguages: [targLang0],
+      // targetLanguages: [targLang0], // add trgLang when we upload, to avoid MT
       notes: ['Note to self']
     }, function (err, resp) {
       if (err) return done(err);


### PR DESCRIPTION
- Don't create the target language until we actually upload target content in the test
- this avoids an MT race condition.

Fixes: #140 