### PR TITLE
add connect(), deprecate getClient()

### DIFF
--- a/API.md
+++ b/API.md
@@ -115,10 +115,13 @@ Usage: <code>var credentials = require(&#39;cfEnv&#39;)
 ## Functions
 
 <dl>
-<dt><a href="#getClient">getClient(params)</a> ⇒ <code><a href="#Client">Client</a></code></dt>
+<dt><del><a href="#getClient">getClient(params)</a> ⇒ <code><a href="#Client">Client</a></code></del></dt>
 <dd><p>Construct a g11n-pipeline client.
 params.credentials is required unless params.appEnv is supplied.
 Required either: (userId &amp; password) or (apikey &amp; iam_endpoint)</p>
+</dd>
+<dt><a href="#connect">connect()</a></dt>
+<dd><p>Create a GP client… returns a promise to the client.</p>
 </dd>
 <dt><a href="#readJson">readJson(filename)</a> ⇒ <code>Promise.&lt;Object&gt;</code></dt>
 <dd><p>Read a file, return promise to parsed obj</p>
@@ -1444,7 +1447,9 @@ Possible translation domains. These provide hints as to the type of translation 
 
 <a name="getClient"></a>
 
-## getClient(params) ⇒ [<code>Client</code>](#Client)
+## ~~getClient(params) ⇒ [<code>Client</code>](#Client)~~
+***Deprecated***
+
 Construct a g11n-pipeline client.
 params.credentials is required unless params.appEnv is supplied.
 Required either: (userId & password) or (apikey & iam_endpoint)
@@ -1463,6 +1468,12 @@ Required either: (userId & password) or (apikey & iam_endpoint)
 | params.credentials.iam_endpoint | <code>string</code> | IAM endpoint |
 | params.credentials.instanceId | <code>string</code> | instance ID |
 
+<a name="connect"></a>
+
+## connect()
+Create a GP client… returns a promise to the client.
+
+**Kind**: global function  
 <a name="readJson"></a>
 
 ## readJson(filename) ⇒ <code>Promise.&lt;Object&gt;</code>

--- a/API.md
+++ b/API.md
@@ -115,13 +115,11 @@ Usage: <code>var credentials = require(&#39;cfEnv&#39;)
 ## Functions
 
 <dl>
-<dt><del><a href="#getClient">getClient(params)</a> ⇒ <code><a href="#Client">Client</a></code></del></dt>
-<dd><p>Construct a g11n-pipeline client.
+<dt><a href="#connect">connect(params)</a> ⇒ <code><a href="#Client">Promise.&lt;Client&gt;</a></code></dt>
+<dd><p>Create a GP client.
+Returns a promise to the client.
 params.credentials is required unless params.appEnv is supplied.
 Required either: (userId &amp; password) or (apikey &amp; iam_endpoint)</p>
-</dd>
-<dt><a href="#connect">connect()</a></dt>
-<dd><p>Create a GP client… returns a promise to the client.</p>
 </dd>
 <dt><a href="#readJson">readJson(filename)</a> ⇒ <code>Promise.&lt;Object&gt;</code></dt>
 <dd><p>Read a file, return promise to parsed obj</p>
@@ -1445,12 +1443,11 @@ Possible translation domains. These provide hints as to the type of translation 
 | ENGYUTL | <code>string</code> | <code>&quot;Energy and utilities&quot;</code> | 
 | AGRICLT | <code>string</code> | <code>&quot;Agriculture&quot;</code> | 
 
-<a name="getClient"></a>
+<a name="connect"></a>
 
-## ~~getClient(params) ⇒ [<code>Client</code>](#Client)~~
-***Deprecated***
-
-Construct a g11n-pipeline client.
+## connect(params) ⇒ [<code>Promise.&lt;Client&gt;</code>](#Client)
+Create a GP client.
+Returns a promise to the client.
 params.credentials is required unless params.appEnv is supplied.
 Required either: (userId & password) or (apikey & iam_endpoint)
 
@@ -1468,12 +1465,6 @@ Required either: (userId & password) or (apikey & iam_endpoint)
 | params.credentials.iam_endpoint | <code>string</code> | IAM endpoint |
 | params.credentials.instanceId | <code>string</code> | instance ID |
 
-<a name="connect"></a>
-
-## connect()
-Create a GP client… returns a promise to the client.
-
-**Kind**: global function  
 <a name="readJson"></a>
 
 ## readJson(filename) ⇒ <code>Promise.&lt;Object&gt;</code>

--- a/README.md
+++ b/README.md
@@ -18,9 +18,9 @@ This SDK currently supports:
 
 ## News
 
+- `getClient()` has been removed. Instead, use `connect()` which returns a `Promise` to a Client object.
 - The CLI is expected to move to a separate package (possibly with a scope). This will lighten
 the dependencies required in this package. See [#158](https://github.com/IBM-Cloud/gp-js-client/issues/158)
-- There's an open discussion about deprecating `getClient()` in favor of a `connect()` which returns a promise. See [#155](https://github.com/IBM-Cloud/gp-js-client/pull/155)
 
 ## Sample
 
@@ -45,7 +45,7 @@ The documentation explains how to find the service on IBM Cloud, create a new se
 ```javascript
 var optional = require('optional');
 var appEnv = require('cfenv').getAppEnv();
-var gpClient = require('g11n-pipeline').getClient(
+var gpClient = await require('g11n-pipeline').connect(
   optional('./local-credentials.json')   // if it exists, use local-credentials.json
     || {appEnv: appEnv}                  // otherwise, the appEnv
 );
@@ -153,7 +153,10 @@ You can call the g11n-pipeline API just as from Node.js:
 ```js
 // mycode.js
 const gp = require('g11n-pipeline');
-gp.getClient({/*...*/}) // do some great stuff here
+gp.connect({/*...*/})
+.then(client => {
+    // do some great stuff here
+});
 ```
 
 And then, package up the code for the browser:

--- a/lib/main.js
+++ b/lib/main.js
@@ -19,17 +19,12 @@ const Consts = require('./consts.js');
 const utils = require('./utils.js');
 
 /**
- * @private
- */
-
-let didWarnGetClient = false;
-
-/**
  * @author Steven R. Loomis
  */
 
 /**
- * Construct a g11n-pipeline client.
+ * Create a GP client.
+ * Returns a promise to the client.
  * params.credentials is required unless params.appEnv is supplied.
  * Required either: (userId & password) or (apikey & iam_endpoint)
  * @param {Object} params - configuration params
@@ -41,32 +36,13 @@ let didWarnGetClient = false;
  * @param {string} params.credentials.apikey - IAM apikey
  * @param {string} params.credentials.iam_endpoint - IAM endpoint
  * @param {string} params.credentials.instanceId - instance ID
- * @returns {Client}
- * @function getClient
- * @deprecated use create() which returns a promise
+ * @function connect
+ * @returns {Promise<Client>}
  */
-exports.getClient = function getClient(params) {
+exports.connect = async function connect(params) {
   const client = new Client(params);
-  /* eslint no-console: "off" */
-  client.swaggerClient.catch((error) => {
-    console.error(`g11n-pipeline: Error connecting to ${params.credentials.url}: ${error.message}`);
-    if(!didWarnGetClient) {
-      didWarnGetClient = true;
-      /* eslint no-irregular-whitespace: "off" */
-      console.warn(`g11n-pipeline: Please use “await require('g11n-pipeline').connect(…)” instead of “.getClient()”`);
-    }
-  });
+  await client.swaggerClient; // ensure the client is ready
   return client;
-};
-
-/**
- * Create a GP client… returns a promise to the client.
- */
-exports.connect = function connect(params) {
-  return new Promise((resolve, reject) => {
-    const client = new Client(params);
-    client.swaggerClient.then(() => resolve(client), (error) => reject(error));
-  });
 };
 
 // re export these…

--- a/lib/main.js
+++ b/lib/main.js
@@ -19,6 +19,12 @@ const Consts = require('./consts.js');
 const utils = require('./utils.js');
 
 /**
+ * @private
+ */
+
+let didWarnGetClient = false;
+
+/**
  * @author Steven R. Loomis
  */
 
@@ -37,9 +43,30 @@ const utils = require('./utils.js');
  * @param {string} params.credentials.instanceId - instance ID
  * @returns {Client}
  * @function getClient
+ * @deprecated use create() which returns a promise
  */
 exports.getClient = function getClient(params) {
-  return new Client(params);
+  const client = new Client(params);
+  /* eslint no-console: "off" */
+  client.swaggerClient.catch((error) => {
+    console.error(`g11n-pipeline: Error connecting to ${params.credentials.url}: ${error.message}`);
+    if(!didWarnGetClient) {
+      didWarnGetClient = true;
+      /* eslint no-irregular-whitespace: "off" */
+      console.warn(`g11n-pipeline: Please use “await require('g11n-pipeline').connect(…)” instead of “.getClient()”`);
+    }
+  });
+  return client;
+};
+
+/**
+ * Create a GP client… returns a promise to the client.
+ */
+exports.connect = function connect(params) {
+  return new Promise((resolve, reject) => {
+    const client = new Client(params);
+    client.swaggerClient.then(() => resolve(client), (error) => reject(error));
+  });
 };
 
 // re export these…

--- a/test/cli-test.js
+++ b/test/cli-test.js
@@ -152,10 +152,9 @@ describe('Setting up cli test', function() {
     });
 
 
-    it('requiring g11n-pipeline with options', function(done) {
-      client = GP.getClient(opts);
+    it('requiring g11n-pipeline with options', async function() {
+      client = await GP.connect(opts);
       //if(VERBOSE) console.log( client._getUrl() );
-      done();
     });
   } else {
     // no creds
@@ -165,17 +164,18 @@ describe('Setting up cli test', function() {
   }
 
   if(serviceInstanceId === randInstanceName) {
-    it(`should let us create the random instance ${randInstanceName}`, () => GP.getClient(opts).restCall("admin.createServiceInstance",
-      {
-        serviceInstanceId,
-        body: {
-          serviceId: 'rand-'+randHex(),
-          orgId: 'rand-'+randHex(),
-          spaceId: 'rand-'+randHex(),
-          planId: 'rand-'+randHex(),
-          disabled: false
-        }
-      }));
+    it(`should let us create the random instance ${randInstanceName}`, async () =>
+      (await GP.connect(opts)).restCall("admin.createServiceInstance",
+        {
+          serviceInstanceId,
+          body: {
+            serviceId: 'rand-'+randHex(),
+            orgId: 'rand-'+randHex(),
+            spaceId: 'rand-'+randHex(),
+            planId: 'rand-'+randHex(),
+            disabled: false
+          }
+        }));
   }
 });
 

--- a/test/client-test.js
+++ b/test/client-test.js
@@ -121,10 +121,9 @@ describe('Setting up GaaS test', function() {
     });
 
 
-    it('requiring gaas with options', function(done) {
-      gaasClient = gaas.getClient(opts);
+    it('requiring gaas with options', async () => {
+      gaasClient = await gaas.connect(opts);
       //if(VERBOSE) console.log( gaasClient._getUrl() );
-      done();
     });
   } else {
     // no creds
@@ -831,16 +830,16 @@ describe('gaasClient.bundle()', function() {
 
   // Let's test that reader user
 
-  it('Should verify the reader user can ping', function(done) {
+  it('Should verify the reader user can ping', async function() {
     expect(myUserInfo).to.be.ok; // otherwise, user creation failed
-    gaasReaderClient = gaas.getClient(readerInfo);
-    gaasReaderClient.ping({}, done);
+    gaasReaderClient = await gaas.connect(readerInfo);
+    await gaasReaderClient.ping();
   });
 
-  it('Should verify the admin user can ping', function(done) {
+  it('Should verify the admin user can ping', async function() {
     expect(adminInfo).to.be.ok; // otherwise, user creation failed
-    gaasAdminClient = gaas.getClient(adminInfo);
-    gaasAdminClient.ping({}, done);
+    gaasAdminClient = (await gaas.connect(adminInfo));
+    await gaasAdminClient.ping();
   });
 
   // Metadata test here.

--- a/test/doc-test.js
+++ b/test/doc-test.js
@@ -91,10 +91,10 @@ describe('Setting up doc test', function() {
     });
 
 
-    it('requiring g11n-pipeline with options', function(done) {
-      client = GP.getClient(opts);
+    it('requiring g11n-pipeline with options', async function() {
+      client = await GP.connect(opts);
+      expect(client).to.be.ok;
       //if(VERBOSE) console.log( client._getUrl() );
-      done();
     });
   } else {
     // no creds

--- a/test/rest-test.js
+++ b/test/rest-test.js
@@ -39,9 +39,9 @@ var gaas = require('../lib/main.js'); // required, below
 var gaasTest = require ('./lib/gp-test');
 var opts = {credentials: gaasTest.getCredentials()};
 var isAdmin = opts.credentials.isAdmin; // admin creds available?
-var gaasClient = gaas.getClient(opts);
+var gaasClient = gaas.connect(opts);
 var basicOpts = {basicAuth: true, credentials: gaasTest.getCredentials()};
-var basicClient = gaas.getClient(basicOpts); // not implemented
+var basicClient = gaas.connect(basicOpts); // not implemented
 var url = gaasClient.url;
 
 var sourceLoc = "en-US";

--- a/test/tr-test.js
+++ b/test/tr-test.js
@@ -85,10 +85,9 @@ var urlEnv = gaas._normalizeUrl(opts.credentials.url); // use GaaS normalize
 
 describe('Setting up GP-HPE test', function () {
   if (urlEnv) {
-    it('requiring gaas with options', function (done) {
-      gaasClient = gaas.getClient(opts);
+    it('requiring gaas with options', async function () {
+      gaasClient = await gaas.connect(opts);
       //if(VERBOSE) console.log( gaasClient._getUrl() );
-      done();
     });
   } else {
     // no creds


### PR DESCRIPTION
~Deprecate~ Remove the `getClient()` function that returns a Client object. (Yes, the main API since the beginning of this project!)

Instead, use `connect()` which returns a promise and actually tries to load the swagger.json. Callers are expected to handle any rejections right away.

Fixes: https://github.com/IBM-Cloud/gp-js-client/issues/101
