### PR TITLE
fix use of deprecated Buffer in hmac

### DIFF
--- a/lib/gp-hmac.js
+++ b/lib/gp-hmac.js
@@ -30,7 +30,7 @@ var GaasHmac = function GaasHmac(name, user, secret) {
   if(!this.name || !this.user || !this.secret) {
     throw new Error('GaasHmac: params need to be "name,user,secret"');
   }
-  this.secretBuffer = new Buffer(this.secret, this.ENC);
+  this.secretBuffer = Buffer.alloc(this.secret.length, this.secret, this.ENC);
 };
 
 GaasHmac.prototype.name = null;

--- a/package-lock.json
+++ b/package-lock.json
@@ -179,14 +179,26 @@
         "to-fast-properties": "^2.0.0"
       }
     },
-    "@evxn/jsonpath": {
-      "version": "1.3.4",
-      "resolved": "https://registry.npmjs.org/@evxn/jsonpath/-/jsonpath-1.3.4.tgz",
-      "integrity": "sha512-eJmX2k0WEQ+Lq9ljAxK4iyCCcY25ynJ1Gv70cZrmxfikF5Qefzb12+xy+Lov3CKvA67kehvbrAKPHZF5IOEBMQ==",
+    "@kyleshockey/js-yaml": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@kyleshockey/js-yaml/-/js-yaml-1.0.1.tgz",
+      "integrity": "sha512-coFyIk1LvTscq1cUU4nCCfYwv+cmG4fCP+wgDKgYZjhM4f++YwZy+g0k+1tUqa4GuUpBTEOGH2KUqKFFWdT73g==",
+      "requires": {
+        "argparse": "^1.0.7"
+      }
+    },
+    "@kyleshockey/object-assign-deep": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/@kyleshockey/object-assign-deep/-/object-assign-deep-0.4.2.tgz",
+      "integrity": "sha1-hJAPDu/DcnmPR1G1JigwuCCJIuw="
+    },
+    "@livereach/jsonpath": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@livereach/jsonpath/-/jsonpath-1.2.2.tgz",
+      "integrity": "sha512-Vovu5kgrnaxzbKa5IuFAFK+m0fsjra/OjPPEwjjVKiSE4eN/69K48aKZRha5vRBrD0uIAlr1JVoG74YPJNzgSQ==",
       "requires": {
         "esprima": "1.2.2",
-        "jison": "0.4.13",
-        "static-eval": "2.0.0",
+        "static-eval": "2.0.2",
         "underscore": "1.7.0"
       },
       "dependencies": {
@@ -201,24 +213,6 @@
           "integrity": "sha1-a7rwh3UA02vjTsqlhODbn+8DUgk="
         }
       }
-    },
-    "@kyleshockey/js-yaml": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@kyleshockey/js-yaml/-/js-yaml-1.0.1.tgz",
-      "integrity": "sha512-coFyIk1LvTscq1cUU4nCCfYwv+cmG4fCP+wgDKgYZjhM4f++YwZy+g0k+1tUqa4GuUpBTEOGH2KUqKFFWdT73g==",
-      "requires": {
-        "argparse": "^1.0.7"
-      }
-    },
-    "@kyleshockey/object-assign-deep": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/@kyleshockey/object-assign-deep/-/object-assign-deep-0.4.2.tgz",
-      "integrity": "sha1-hJAPDu/DcnmPR1G1JigwuCCJIuw="
-    },
-    "JSONSelect": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/JSONSelect/-/JSONSelect-0.4.0.tgz",
-      "integrity": "sha1-oI7cxn6z/L6Z7WMIVTRKDPKCu40="
     },
     "abbrev": {
       "version": "1.0.9",
@@ -620,11 +614,6 @@
       "integrity": "sha512-UZK3NBx2Mca+b5LsG7bY183pHWt5Y1xts4P3Pz7ENTwGVnJOUWbRb3ocjvX7hx9tq/yTAdclXm9sZ38gNuem4A==",
       "dev": true
     },
-    "cjson": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/cjson/-/cjson-0.2.1.tgz",
-      "integrity": "sha1-c82KrWXZ4VBfmvF0TTt5wVJ2gqU="
-    },
     "cli-cursor": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
@@ -704,11 +693,6 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
       "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
       "dev": true
-    },
-    "colors": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/colors/-/colors-0.5.1.tgz",
-      "integrity": "sha1-fQAj6usVTo7p/Oddy5I9DtFmd3Q="
     },
     "combined-stream": {
       "version": "1.0.6",
@@ -1039,11 +1023,6 @@
       "requires": {
         "esutils": "^2.0.2"
       }
-    },
-    "ebnf-parser": {
-      "version": "0.1.10",
-      "resolved": "https://registry.npmjs.org/ebnf-parser/-/ebnf-parser-0.1.10.tgz",
-      "integrity": "sha1-zR9rpHfFY4xAyX7ZtXLbW6tdgzE="
     },
     "ecc-jsbn": {
       "version": "0.1.1",
@@ -1547,11 +1526,11 @@
       "dev": true
     },
     "g11n-pipeline-flatten": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/g11n-pipeline-flatten/-/g11n-pipeline-flatten-2.0.0.tgz",
-      "integrity": "sha512-qcrlLNJaocb5I0bqxC32tVi+YAXV8MLLMG2N+7aCgIJxnpPr9a0LOswJDxbrmuu0hykWKfLH3xziFd/96sacvw==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/g11n-pipeline-flatten/-/g11n-pipeline-flatten-2.0.1.tgz",
+      "integrity": "sha512-HRduCmuoICbBvyUM1TGxjRp9mgyp34I6gXTlp699vfMOXsSCx1oVEWM87A046IcG/uuck5v4zM0WTjfjwyx4dA==",
       "requires": {
-        "@evxn/jsonpath": "^1.3.4"
+        "@livereach/jsonpath": "^1.2.2"
       }
     },
     "get-caller-file": {
@@ -2169,52 +2148,6 @@
         "handlebars": "^4.1.0"
       }
     },
-    "jison": {
-      "version": "0.4.13",
-      "resolved": "https://registry.npmjs.org/jison/-/jison-0.4.13.tgz",
-      "integrity": "sha1-kEFwfWIkE2f1iDRTK58ZwsNvrHg=",
-      "requires": {
-        "JSONSelect": "0.4.0",
-        "cjson": "~0.2.1",
-        "ebnf-parser": "~0.1.9",
-        "escodegen": "0.0.21",
-        "esprima": "1.0.x",
-        "jison-lex": "0.2.x",
-        "lex-parser": "~0.1.3",
-        "nomnom": "1.5.2"
-      },
-      "dependencies": {
-        "escodegen": {
-          "version": "0.0.21",
-          "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-0.0.21.tgz",
-          "integrity": "sha1-U9ZSz6EDA4gnlFilJmxf/HCcY8M=",
-          "requires": {
-            "esprima": "~1.0.2",
-            "estraverse": "~0.0.4",
-            "source-map": ">= 0.1.2"
-          }
-        },
-        "esprima": {
-          "version": "1.0.4",
-          "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz",
-          "integrity": "sha1-n1V+CPw7TSbs6d00+Pv0drYlha0="
-        },
-        "estraverse": {
-          "version": "0.0.4",
-          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-0.0.4.tgz",
-          "integrity": "sha1-AaCTLf7ldGhKWYr1pnw7+bZCjbI="
-        }
-      }
-    },
-    "jison-lex": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/jison-lex/-/jison-lex-0.2.1.tgz",
-      "integrity": "sha1-rEuBXozOUTLrErXfz+jXB7iETf4=",
-      "requires": {
-        "lex-parser": "0.1.x",
-        "nomnom": "1.5.2"
-      }
-    },
     "js-tokens": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
@@ -2399,11 +2332,6 @@
         "prelude-ls": "~1.1.2",
         "type-check": "~0.3.2"
       }
-    },
-    "lex-parser": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/lex-parser/-/lex-parser-0.1.4.tgz",
-      "integrity": "sha1-ZMTwJfF/1Tv7RXY/rrFvAVp0dVA="
     },
     "load-json-file": {
       "version": "4.0.0",
@@ -2728,22 +2656,6 @@
       "requires": {
         "encoding": "^0.1.11",
         "is-stream": "^1.0.1"
-      }
-    },
-    "nomnom": {
-      "version": "1.5.2",
-      "resolved": "https://registry.npmjs.org/nomnom/-/nomnom-1.5.2.tgz",
-      "integrity": "sha1-9DRUSKhTz71cDSYyDyR3qwUm/i8=",
-      "requires": {
-        "colors": "0.5.x",
-        "underscore": "1.1.x"
-      },
-      "dependencies": {
-        "underscore": {
-          "version": "1.1.7",
-          "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.1.7.tgz",
-          "integrity": "sha1-QLq4S60Z0jAJbo1u9ii/8FXYPbA="
-        }
       }
     },
     "nopt": {
@@ -3693,9 +3605,9 @@
       }
     },
     "static-eval": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/static-eval/-/static-eval-2.0.0.tgz",
-      "integrity": "sha512-6flshd3F1Gwm+Ksxq463LtFd1liC77N/PX1FVVc3OzL3hAmo2fwHFbuArkcfi7s9rTNsLEhcRmXGFZhlgy40uw==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/static-eval/-/static-eval-2.0.2.tgz",
+      "integrity": "sha512-N/D219Hcr2bPjLxPiV+TQE++Tsmrady7TqAJugLy7Xk1EumfDWS/f5dtBbkRCGE7wKKXuYockQoj8Rm2/pVKyg==",
       "requires": {
         "escodegen": "^1.8.1"
       }

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
   },
   "dependencies": {
     "bent": "^1.4.0",
-    "g11n-pipeline-flatten": "^2.0.0",
+    "g11n-pipeline-flatten": "^2.0.1",
     "minimist": "^1.2.0",
     "swagger-client": "^3.8.25"
   },


### PR DESCRIPTION
See: https://nodejs.org/api/deprecations.html#deprecations_dep0005_buffer_constructor

The use of `Buffer()` was deprecated, the API used in this PR dates from Node version 5, and we require Node version 8+ for this SDK. So it is a safe replacement.